### PR TITLE
Limit list_resource page size and add a default return for IncidentApi

### DIFF
--- a/src/armorblox/api/base_api.py
+++ b/src/armorblox/api/base_api.py
@@ -51,7 +51,7 @@ class BaseApi:
         p = self.list_params()
         if params is not None:
             p.update(params)
-            #Cap page size to 50 for optimal performance
+            # Cap page size to 50 for optimal performance
             p["page_size"] = min(p["page_size"], self.PAGE_SIZE)
         if options is None:
             options = {}

--- a/src/armorblox/api/base_api.py
+++ b/src/armorblox/api/base_api.py
@@ -51,7 +51,7 @@ class BaseApi:
         p = self.list_params()
         if params is not None:
             p.update(params)
-            # Cap page size to 50 for optimal performance
+            # Cap page size to PAGE_SIZE value for optimal performance
             p["page_size"] = min(p["page_size"], self.PAGE_SIZE)
         if options is None:
             options = {}

--- a/src/armorblox/api/base_api.py
+++ b/src/armorblox/api/base_api.py
@@ -51,10 +51,12 @@ class BaseApi:
         p = self.list_params()
         if params is not None:
             p.update(params)
+            #Cap page size to 50 for optimal performance
+            p["page_size"] = min(p["page_size"], self.PAGE_SIZE)
         if options is None:
             options = {}
         response = requests.get(self.endpoint(path, options.get('api_version')),
-                                headers=h, params=params)
+                                headers=h, params=p)
         if response.status_code == 200:
             return response.json(), None
         else:

--- a/src/armorblox/api/incidents_api.py
+++ b/src/armorblox/api/incidents_api.py
@@ -34,7 +34,7 @@ class IncidentsApi(BaseApi):
 
         response_json, response = self.list_resource(self.PATH, params=params)
         if response_json is None:
-            return []
+            return [], None, 0
         else:
             next_page_token = response_json.get('next_page_token', None)
             total_count = int(response_json.get('total_count', 0))


### PR DESCRIPTION
Return a default value for incidents, token and count when no incidents are found with the list method in IncidentApi.
Changes for list_resource:
Capped page_size to 50 for optimal performance.
Use the default dictionary p and update if any params are passed by the caller.